### PR TITLE
APPEND CMAKE_MODULE_PATH instead of overwriting

### DIFF
--- a/ariles/CMakeLists.txt
+++ b/ariles/CMakeLists.txt
@@ -6,8 +6,7 @@ set(PROJECT_VERSION_MAJOR 1)
 set(PROJECT_VERSION_MINOR 6)
 set(PROJECT_VERSION_PATCH 6)
 
-set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
-
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 
 
 #####################################


### PR DESCRIPTION
This fixes a CMake warning in dependent packages.
```
CMake Warning (dev) at /opt/ros/melodic/share/...
  Cannot set "CMAKE_MODULE_PATH": current scope has no parent
```