### PR TITLE
Updating to cmake policy CMP0048 for versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
+cmake_policy(SET CMP0048 NEW)
 project(ariles_ros VERSION 1.6.6)
 
 

--- a/ariles/CMakeLists.txt
+++ b/ariles/CMakeLists.txt
@@ -1,10 +1,9 @@
 # General parameters
-cmake_minimum_required (VERSION 2.8.12)
-project (ariles CXX)
+cmake_minimum_required(VERSION 3.0)
+cmake_policy(SET CMP0048 NEW)
+project(ariles LANGUAGES CXX VERSION 1.6.6)
+
 set(ARILES_HOMEPAGE http://asherikov.github.com/ariles/)
-set(PROJECT_VERSION_MAJOR 1)
-set(PROJECT_VERSION_MINOR 6)
-set(PROJECT_VERSION_PATCH 6)
 
 set (CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")
 


### PR DESCRIPTION
This fixes is warning
```
CMake Warning (dev) at ariles/CMakeLists.txt:3 (project):
  Policy CMP0048 is not set: project() command manages VERSION variables.
  Run "cmake --help-policy CMP0048" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  The following variable(s) would be set to empty:

    PROJECT_VERSION
    PROJECT_VERSION_MAJOR
    PROJECT_VERSION_MINOR
    PROJECT_VERSION_PATCH
This warning is for project developers.  Use -Wno-dev to suppress it.
```

Moved to requiring cmake 3.0 to avoid ifdef-ing as it is in use elsewhere.